### PR TITLE
Improve Windows usability for OCR CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# 日文影像 OCR 工具
+
+這個專案提供一個命令列工具，透過 OpenAI Responses API 將影像中的日文文字辨識後輸出為 Markdown 檔案。
+
+## 需求
+
+- Python 3.10+
+- 安裝 [`openai`](https://pypi.org/project/openai/) 套件：
+  ```bash
+  pip install openai
+  ```
+- 將 `OPENAI_API_KEY` 環境變數設定為你的 API 金鑰：
+  - macOS / Linux（bash、zsh）：`export OPENAI_API_KEY=你的金鑰`
+  - Windows PowerShell：`$env:OPENAI_API_KEY = "你的金鑰"`
+  - Windows 命令提示字元 (CMD)：`set OPENAI_API_KEY=你的金鑰`
+
+## 使用方式
+
+```bash
+python ocr_japanese.py path/to/image1.png /path/to/book_scans -o ./output
+```
+
+- `path/to/image*.png`：要進行 OCR 的影像路徑，可以一次提供多個。Windows 使用者也可以直接在命令列輸入萬用字元（例如 `*.png`），程式會自動展開對應的檔案。
+- `/path/to/book_scans`：如果改提供目錄，程式會自動偵測其中所有支援的影像檔（依數字順序排序），並將辨識結果合併輸出成單一 Markdown 檔案，檔名為目錄名稱。
+- `-o/--output-dir`：指定輸出資料夾，預設為 `./ocr_output`。
+- `--model`：可選擇不同的 OpenAI 模型，預設為 `gpt-4.1-mini`。
+
+對於單張影像，程式會產生對應檔名的 `.md` 檔案；對於目錄，會產生合併後的單一 Markdown。

--- a/ocr_japanese.py
+++ b/ocr_japanese.py
@@ -1,0 +1,186 @@
+"""Command-line tool to OCR Japanese text from images using OpenAI's Responses API."""
+from __future__ import annotations
+
+import argparse
+import os
+from glob import glob
+from pathlib import Path
+from typing import Iterable
+
+from openai import OpenAI
+
+
+PROMPT = (
+    "You are an OCR assistant. Transcribe all Japanese text from the image. "
+    "Preserve the reading order as much as possible and keep the output in Markdown."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Transcribe Japanese text from images via the OpenAI API and save to Markdown files.",
+    )
+    parser.add_argument(
+        "images",
+        nargs="+",
+        help="Paths to image files to transcribe.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="./ocr_output",
+        help=(
+            "Directory where Markdown files should be written. "
+            "If omitted, files are saved in ./ocr_output."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-4.1-mini",
+        help="OpenAI model to use for OCR (default: gpt-4.1-mini).",
+    )
+    return parser.parse_args()
+
+
+def ensure_output_dir(path: str | os.PathLike[str]) -> Path:
+    output_path = Path(path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    return output_path
+
+
+def response_to_text(response) -> str:
+    """Extract plain text from a Responses API call."""
+    if hasattr(response, "output_text"):
+        return response.output_text
+
+    # Fallback in case output_text is unavailable (older client versions).
+    text_parts: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        content = getattr(item, "content", []) or []
+        for block in content:
+            if getattr(block, "type", None) == "output_text":
+                text_parts.append(getattr(block, "text", ""))
+    return "\n".join(text_parts)
+
+
+def save_markdown(text: str, target_path: Path) -> None:
+    target_path.write_text(text, encoding="utf-8")
+
+
+def guess_output_filename(image_path: Path) -> str:
+    return f"{image_path.stem}.md"
+
+
+def call_ocr(client: OpenAI, model: str, image_path: Path) -> str:
+    with image_path.open("rb") as image_file:
+        response = client.responses.create(
+            model=model,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": PROMPT},
+                        {"type": "input_image", "image": image_file},
+                    ],
+                }
+            ],
+        )
+    return response_to_text(response)
+
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff"}
+
+
+def natural_sort_key(path: Path) -> tuple:
+    """Return a key that sorts filenames in human order (e.g., 1, 2, 10)."""
+    parts: list[tuple[int, int | str]] = []
+    token = ""
+    for char in path.stem:
+        if char.isdigit():
+            token += char
+        else:
+            if token:
+                parts.append((0, int(token)))
+                token = ""
+            parts.append((1, char.lower()))
+    if token:
+        parts.append((0, int(token)))
+    return tuple(parts)
+
+
+def iter_images_in_directory(directory: Path) -> list[Path]:
+    return sorted(
+        [p for p in directory.iterdir() if p.suffix.lower() in IMAGE_EXTENSIONS and p.is_file()],
+        key=natural_sort_key,
+    )
+
+
+def process_single_image(client: OpenAI, model: str, image_path: Path, output_dir: Path) -> None:
+    print(f"Processing {image_path} ...")
+    text = call_ocr(client, model, image_path)
+    output_file = output_dir / guess_output_filename(image_path)
+    save_markdown(text, output_file)
+    print(f"Saved Markdown to {output_file}")
+
+
+def process_image_directory(client: OpenAI, model: str, directory: Path, output_dir: Path) -> None:
+    images = iter_images_in_directory(directory)
+    if not images:
+        raise FileNotFoundError(f"No images found in directory: {directory}")
+
+    combined_parts: list[str] = []
+    for image in images:
+        print(f"Processing {image} ...")
+        text = call_ocr(client, model, image)
+        combined_parts.append(f"## {image.stem}\n\n{text}")
+
+    combined_output = "\n\n".join(part.strip() for part in combined_parts if part.strip())
+    output_file = output_dir / f"{directory.name}.md"
+    save_markdown(combined_output, output_file)
+    print(f"Saved combined Markdown to {output_file}")
+
+
+def expand_inputs(image_paths: Iterable[str]) -> list[Path]:
+    expanded: list[Path] = []
+    for raw_path in image_paths:
+        if any(char in raw_path for char in "*?[]"):
+            matches = sorted(
+                (Path(match) for match in glob(raw_path, recursive=True)),
+                key=lambda p: str(p).lower(),
+            )
+            if not matches:
+                raise FileNotFoundError(f"No files matched the pattern: {raw_path}")
+            expanded.extend(matches)
+            continue
+
+        expanded.append(Path(raw_path))
+
+    if not expanded:
+        raise FileNotFoundError("No input images or directories were provided.")
+
+    return expanded
+
+
+def process_images(image_paths: Iterable[Path], output_dir: Path, model: str) -> None:
+    client = OpenAI()
+
+    for path in image_paths:
+        if path.is_dir():
+            process_image_directory(client, model, path, output_dir)
+            continue
+
+        if not path.is_file():
+            raise FileNotFoundError(f"Image not found: {path}")
+
+        process_single_image(client, model, path, output_dir)
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = ensure_output_dir(args.output_dir)
+    inputs = expand_inputs(args.images)
+    process_images(inputs, output_dir, args.model)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand input handling to resolve glob patterns so Windows shells can pass wildcards directly
- normalize output directory creation with user home expansion for consistent cross-platform paths
- document Windows-specific environment variable setup and wildcard usage in the README

## Testing
- python -m compileall ocr_japanese.py

------
https://chatgpt.com/codex/tasks/task_b_68e4556fdef883268444eed04a862795